### PR TITLE
Basic grouping and tab navigation support with highlight

### DIFF
--- a/war/js/cwl-hierarchy.js
+++ b/war/js/cwl-hierarchy.js
@@ -2,14 +2,11 @@
 //   Special dispensation to ignore OpenWorm since it is the master
 //   root.
 
-var currRootId = 0;
-
 // **CWL** Used an object for index and delete convenience
 var currRoots = {};
 
 // Parent and child relationships are both captured in the event
 //   the (manual) specifications are disjoint or incomplete
-var childOf = {};
 var parentOf = {};
 
 var add_to_hierarchy = function(child, parent) {
@@ -22,7 +19,6 @@ var add_to_hierarchy = function(child, parent) {
     } else {
 	// Remove any existing children as roots
 	delete currRoots[child];
-	childOf[parent] = child;
 	parentOf[child] = parent;
     }
 };
@@ -42,16 +38,33 @@ var find_ancestor = function(element) {
     } else {
 	return find_ancestor(parentOf[element]);
     }
-}
+};
 
-var build_hierarchy = function(container) {
+var build_hierarchy = function() {
     var key;
-    //    for (key in currRoots) {
     Object.keys(currRoots).forEach(function(key,index) {
-	    navLookup[key] = "metaroot" + currRootId++;
+	groupLookup[key] = index;
+	// create a top-level div for it
+	if (index == 0) {
+	    $("#content").append('<div class="tab-pane fade in active" id="' + domGroup + index + '"></div>');
+	} else {
+	    $("#content").append('<div class="tab-pane fade" id="' + domGroup + index + '"></div>');
+	}
+	// insert the root element into its own group
+	$('#' + domElement + elementLookup[key]).appendTo('#' + domGroup + groupLookup[key]);
 	});
-    // Time to flatten the tree
+    // Flatten the tree, place each child into its root's div block
     for (key in parentOf) {
-	navLookup[key] = navLookup[find_ancestor(key)];
+	groupLookup[key] = groupLookup[find_ancestor(key)];
+	$('#' + domElement + elementLookup[key]).appendTo('#' + domGroup + groupLookup[key]);
     }
+};
+
+var disable_untracked_nav_buttons = function() {
+    $('.navBtn').each(function() {
+	    var textkey = this.innerHTML;
+	    if (elementLookup[textkey] == undefined) {
+		$(this).addClass('disabled');
+	    }
+	});
 };

--- a/war/js/cwl-hierarchy.js
+++ b/war/js/cwl-hierarchy.js
@@ -1,0 +1,57 @@
+// **CWL** builds a single level element-block "hierarchy"
+//   Special dispensation to ignore OpenWorm since it is the master
+//   root.
+
+var currRootId = 0;
+
+// **CWL** Used an object for index and delete convenience
+var currRoots = {};
+
+// Parent and child relationships are both captured in the event
+//   the (manual) specifications are disjoint or incomplete
+var childOf = {};
+var parentOf = {};
+
+var add_to_hierarchy = function(child, parent) {
+    // Special check for OpenWorm as parent.
+    //   This takes care of the case when OpenWorm claims 
+    //     children (it shouldn't) or if someone claims
+    //     OpenWorm as a parent.
+    if (parent == "openworm/OpenWorm") {
+	currRoots[child] = "foo";
+    } else {
+	// Remove any existing children as roots
+	delete currRoots[child];
+	childOf[parent] = child;
+	parentOf[child] = parent;
+    }
+};
+
+var add_to_root = function(element) {
+    // Add to collection of root elements if no one
+    //   else claims it to be their child.
+    if (parentOf[element] == undefined)  {
+	currRoots[element] = "foo";
+    }
+};
+
+var find_ancestor = function(element) {
+    // I am my ancestor
+    if (currRoots[element] != undefined) {
+	return element;
+    } else {
+	return find_ancestor(parentOf[element]);
+    }
+}
+
+var build_hierarchy = function(container) {
+    var key;
+    //    for (key in currRoots) {
+    Object.keys(currRoots).forEach(function(key,index) {
+	    navLookup[key] = "metaroot" + currRootId++;
+	});
+    // Time to flatten the tree
+    for (key in parentOf) {
+	navLookup[key] = navLookup[find_ancestor(key)];
+    }
+};

--- a/war/js/cwlpager.js
+++ b/war/js/cwlpager.js
@@ -6,11 +6,16 @@ var cwlpager_init = function(container,repoNavList) {
 
   while (numItems > curr) {
     if (curr == 0) {
-	$('#tabber').append('<li class="active"><a href="#meta' + curr + '" class="page_link" data-toggle="tab">'+repoNavList[curr]+'</a></li>');
+	$('#tabber').append('<li class="active"><a href="#meta' + curr + '" class="page_link" data-toggle="tab" id="tab_meta' + curr + '">'+repoNavList[curr]+'</a></li>');
 	//	$(".metaElement").filter("#meta" + curr).show();
     } else {
-	$('#tabber').append('<li><a href="#meta' + curr + '" class="page_link" data-toggle="tab">'+repoNavList[curr]+'</a></li>');
+	$('#tabber').append('<li><a href="#meta' + curr + '" class="page_link" data-toggle="tab" id="tab_meta' + curr + '">'+repoNavList[curr]+'</a></li>');
     }
     curr++;
   }
+
+  $('.navBtn').on("click", function() {
+	  var btn_name = this.innerHTML;
+	  $('#tab_' + navLookup[btn_name]).trigger('click');
+      });
 }

--- a/war/js/cwlpager.js
+++ b/war/js/cwlpager.js
@@ -1,21 +1,23 @@
-var cwlpager_init = function(container,repoNavList) {
+var cwlpager_init = function(container) {
 
-  var numItems = container.find(".tab-pane").size();
-  var curr = 0;
   var currMeta;
 
-  while (numItems > curr) {
-    if (curr == 0) {
-	$('#tabber').append('<li class="active"><a href="#meta' + curr + '" class="page_link" data-toggle="tab" id="tab_meta' + curr + '">'+repoNavList[curr]+'</a></li>');
-	//	$(".metaElement").filter("#meta" + curr).show();
-    } else {
-	$('#tabber').append('<li><a href="#meta' + curr + '" class="page_link" data-toggle="tab" id="tab_meta' + curr + '">'+repoNavList[curr]+'</a></li>');
-    }
-    curr++;
-  }
+  Object.keys(currRoots).forEach(function(rootkey,index) {
+      if (index == 0) {
+	  $('#tabber').append('<li class="active"><a href="#' + navElementLookup[rootkey] + '" class="page_link" data-toggle="tab" id="tab_' + navLookup[rootkey] + '">' + rootkey + '</a></li>');
+      } else {
+	  $('#tabber').append('<li><a href="#' + navElementLookup[rootkey] + '" class="page_link" data-toggle="tab" id="tab_' + navLookup[rootkey] + '">' + rootkey + '</a></li>');
+      }
+  });
 
   $('.navBtn').on("click", function() {
 	  var btn_name = this.innerHTML;
 	  $('#tab_' + navLookup[btn_name]).trigger('click');
+	  if (currMeta != undefined) {
+	      $(currMeta).css({"border-style": "none"});
+	  }
+	  $('#' + navElementLookup[btn_name]).css({"border-color": "red", 
+						   "border-width":"1px", 
+						   "border-style":"solid"});
       });
 }

--- a/war/js/cwlpager.js
+++ b/war/js/cwlpager.js
@@ -1,23 +1,60 @@
 var cwlpager_init = function(container) {
 
-  var currMeta;
+  var currElement;
+  var currHighlightedDom;
+  var currGroup;
+  
+  var isBtnTransition = false;
+
+  var highlight_element = function(key) {
+      // remove previous highlight if applicable
+      if (currHighlightedDom != undefined) {
+	  currHighlightedDom.css({"border-style": "none"});
+      }
+
+      currElement = elementLookup[key];
+      currHighlightedDom = $('#' + domElement + currElement);
+      currHighlightedDom.css({"border-color":"red", 
+		  "border-width":"1px", 
+		  "border-style":"solid"});
+  };
+  
 
   Object.keys(currRoots).forEach(function(rootkey,index) {
       if (index == 0) {
-	  $('#tabber').append('<li class="active"><a href="#' + navElementLookup[rootkey] + '" class="page_link" data-toggle="tab" id="tab_' + navLookup[rootkey] + '">' + rootkey + '</a></li>');
+	  $('#tabber').append('<li class="active"><a href="#' + domGroup + groupLookup[rootkey] + '" class="page_link" data-toggle="tab" id="' + tabGroup + groupLookup[rootkey] + '">' + rootkey + '</a></li>');
+	  currGroup = groupLookup[rootkey];
+	  highlight_element(rootkey);
       } else {
-	  $('#tabber').append('<li><a href="#' + navElementLookup[rootkey] + '" class="page_link" data-toggle="tab" id="tab_' + navLookup[rootkey] + '">' + rootkey + '</a></li>');
+	  $('#tabber').append('<li><a href="#' + domGroup + groupLookup[rootkey] + '" class="page_link" data-toggle="tab" id="' + tabGroup + groupLookup[rootkey] + '">' + rootkey + '</a></li>');
       }
   });
 
+
   $('.navBtn').on("click", function() {
-	  var btn_name = this.innerHTML;
-	  $('#tab_' + navLookup[btn_name]).trigger('click');
-	  if (currMeta != undefined) {
-	      $(currMeta).css({"border-style": "none"});
+	  if ($(this).is(":disabled")) {
+	      return;
 	  }
-	  $('#' + navElementLookup[btn_name]).css({"border-color": "red", 
-						   "border-width":"1px", 
-						   "border-style":"solid"});
+	  var btn_name = this.innerHTML;
+
+	  var desiredGroup = groupLookup[btn_name];
+	  highlight_element(btn_name);
+	  if (desiredGroup != currGroup) {
+	      isBtnTransition = true;
+	      $('#' + tabGroup + desiredGroup).trigger('click');
+	  }
       });
-}
+
+
+  $('a[data-toggle="tab"]').on('click', function (e) {
+      var targetkey = $(e.target).text(); // activated tab
+      currGroup = groupLookup[targetkey];
+      if (!isBtnTransition) {
+	  // highlight the root element if user clicked on tab explicitly
+	  highlight_element(targetkey);
+      } else {
+	  // reset flag if transition was the result of a button click
+	  isBtnTransition = false;
+      }
+      });
+};

--- a/war/js/repositories.js
+++ b/war/js/repositories.js
@@ -6,7 +6,11 @@ var urls = [
     "https://cdn.rawgit.com/openworm/org.geppetto/master/.openworm.yml"
 ];
 
+// *CWL* Hardcoded github root url
+var repo_url = "https://github.com/"
+
 var repoNavList = [];
+var navLookup = {};
 
 var fetch = function(container, urls, index) {
 
@@ -29,6 +33,10 @@ var fetch = function(container, urls, index) {
 	    } else {
 		inner = $('<div class="tab-pane fade" id="meta' + index + '" ></div>');
 	    }
+	    
+	    // **CWL** Kind of a hack for now. Establish a string->meta lookuptable.
+	    navLookup[nativeObject.repo] = "meta" + index;
+
 	    // **CWL** and this is the solution for hiding everything at first.
 	    //   Initially I had tried to hide the container before going into this
 	    //   loop but that didn't work out very well.
@@ -55,29 +63,30 @@ var fetch = function(container, urls, index) {
             inner.append('<p><b>Coordinator:</b> ' + nativeObject.coordinator + '</p>');
 
             if (nativeObject.parent != undefined) {
-            	inner.append('<p><b>Parent:</b> ' + nativeObject.parent[0] + '</p>');
+            	inner.append('<p><b>Parent:</b> <a class="btn btn-link" href="' + repo_url + nativeObject.parent[0] + '">Visit Repo</a> <a class="btn btn-primary btn-xs navBtn" href="#">' + nativeObject.parent[0] + '</a></p>');
             }
 
             if (nativeObject.inputs != undefined) {
-            	inner.append('<p><b>Outputs:</b></p>');
+            	inner.append('<p><b>Inputs:</b></p>');
                 for (var i = 0; i < nativeObject.inputs.length; i++) {
-                	inner.append('<p><div>' + nativeObject.inputs[i] + '</div></p>');
+		    inner.append('<p><a class="btn btn-link" href="' + repo_url + nativeObject.inputs[i] + '">Visit Repo</a> <a class="btn btn-primary btn-xs navBtn" href="#">' + nativeObject.inputs[i] + '</a></p>');
                 }
             }
             
             if (nativeObject.outputs != undefined) {
             	inner.append('<p><b>Outputs:</b></p>');
                 for (var i = 0; i < nativeObject.outputs.length; i++) {
-                	inner.append('<p><div>' + nativeObject.outputs[i] + '</div></p>');
+		    inner.append('<p><a class="btn btn-link" href="' + repo_url + nativeObject.outputs[i] + '">Visit Repo</a> <a class="btn btn-primary btn-xs navBtn" href="#">' + nativeObject.outputs[i] + '</a></p>');
                 }
             }
 
             if (nativeObject.children != undefined) {
             	inner.append('<p><b>Children:</b></p>');
                 for (var i = 0; i < nativeObject.children.length; i++) {
-                	inner.append('<p><div>' + nativeObject.children[i] + '</div></p>');
+		    inner.append('<p><a class="btn btn-link" href="' + repo_url + nativeObject.children[i] + '">Visit Repo</a> <a class="btn btn-primary btn-xs navBtn" href="#">' + nativeObject.children[i] + '</a></p>');
                 }
             }
+
 
             if(index < urls.length - 1){
             	inner.append('<hr style="height: 1px; border-color: black;">');
@@ -87,6 +96,11 @@ var fetch = function(container, urls, index) {
             if (urls.length - 1 > index) {
                 fetch(container, urls, index + 1);
             } else {
+		// **CWL** Insert post-processing function here:
+		//    1. build tree
+		//    2. establish navigation links
+		//
+
 		// **CWL** Generate tabs from newly acquired data
 		// handle asynchrony issues by making sure all elements are populated.
 		cwlpager_init(container,repoNavList);

--- a/war/js/repositories.js
+++ b/war/js/repositories.js
@@ -5,7 +5,7 @@ var urls = [
     "https://cdn.rawgit.com/openworm/OpenWorm/master/.openworm.yml",
     "https://cdn.rawgit.com/openworm/hodgkin_huxley_tutorial/master/.openworm.yml",
     "https://cdn.rawgit.com/openworm/openworm_docs/master/.openworm.yml",
-    //    "https://cdn.rawgit.com/openworm/simple-C-elegans/master/.openworm.yml",
+    //"https://cdn.rawgit.com/openworm/simple-C-elegans/master/.openworm.yml",
     "https://cdn.rawgit.com/openworm/wormbrowser/master/.openworm.yml",
     //    "https://cdn.rawgit.com/openworm/sibernetic/master/.openworm.yml",
     "https://cdn.rawgit.com/openworm/openwormbrowser-ios/master/.openworm.yml",
@@ -21,10 +21,17 @@ var urls = [
 ];
 
 // *CWL* Hardcoded github root url
-var repo_url = "https://github.com/"
+var repo_url = "https://github.com/";
 
-var navLookup = {};
-var navElementLookup = {};
+// *CWL* Global names for DOM ids used
+var domElement = "domElement";
+var domGroup = "domGroup";
+var tabGroup = "tabGroup";
+
+// *CWL* establishes relationship between repo keys and indices.
+//   Indices are used as part of DOM ids.
+var groupLookup = {};
+var elementLookup = {};
 
 var fetch = function(container, urls, index) {
 
@@ -43,14 +50,10 @@ var fetch = function(container, urls, index) {
 	    //   issues with basic tabs. The question now is how we can
 	    //   use buttons to work as if a tab had been clicked.
 	    var inner;
-	    if (index == 0) {
-		inner = $('<div class="tab-pane fade in active" id="meta' + index + '" ></div>');
-	    } else {
-		inner = $('<div class="tab-pane fade" id="meta' + index + '" ></div>');
-	    }
+	    inner = $('<div id="' + domElement + index + '" ></div>');
 	    
 	    // **CWL** Kind of a hack for now. Establish a string->meta lookuptable.
-	    navElementLookup[nativeObject.repo] = "meta" + index;
+	    elementLookup[nativeObject.repo] = index;
 
 	    // **CWL** and this is the solution for hiding everything at first.
 	    //   Initially I had tried to hide the container before going into this
@@ -107,15 +110,14 @@ var fetch = function(container, urls, index) {
 		add_to_root(nativeObject.repo);
 	    }
 
-            if(index < urls.length - 1){
-            	inner.append('<hr style="height: 1px; border-color: black;">');
-            }
+	    inner.append('<hr style="height: 1px; border-color: black;">');
 
             // fetch next
             if (urls.length - 1 > index) {
                 fetch(container, urls, index + 1);
             } else {
-		build_hierarchy(container);
+		build_hierarchy();
+		disable_untracked_nav_buttons();
 		// **CWL** Generate tabs from newly acquired data
 		// handle asynchrony issues by making sure all elements are populated.
 		cwlpager_init(container);

--- a/war/repositories.html
+++ b/war/repositories.html
@@ -93,14 +93,6 @@
 			</div>
 		</header>
 
-<!--
-		<div class="hidden" id="foobar">
-			<div id="debug" style="margin-top: 25px;">
-			  <p> Some crap here </p>
-			</div>
-		</div>
--->
-
 		<div class="container">
 		  <div class="row-fluid">
 		    <div class="span12">

--- a/war/repositories.html
+++ b/war/repositories.html
@@ -22,6 +22,7 @@
 		<script type="text/javascript" src="js/jquery-1.8.3.min.js"></script>
 		<script type="text/javascript" src="js/yaml.js"></script>
 		<script type="text/javascript" src="js/repositories.js"></script>
+		<script type="text/javascript" src="js/cwl-hierarchy.js"></script>
 		<script type="text/javascript" src="js/cwlpager.js"></script>
 
 		<!-- HTML5 shim, for IE6-8 support of HTML5 elements -->


### PR DESCRIPTION
Added a special single-level grouping methodology for tabs (so openworm/OpenWorm does not become its only tab) as follows:

1. openworm/OpenWorm has it's own tab.
2. immediate children of openworm/OpenWorm have their own tabs.
3. repos without parents have their own tabs.
4. all recursive descendants of repos with tabs are grouped under that tab.

Known issues (annoyances rather than bugs):
1. clicking on a navigation button for a repo that is un-represented in the tree results in highlights getting cleared.
2. navigation buttons for repos that are un-represented in the tree can be disabled but it does not stop the clicks from taking effect.