### PR TITLE
Support for multiple metadata views

### DIFF
--- a/war/js/repositories.js
+++ b/war/js/repositories.js
@@ -23,6 +23,9 @@ var urls = [
 // *CWL* Hardcoded github root url
 var repo_url = "https://github.com/";
 
+// *CWL* Construction of javascript array for jsGrid data
+var metadata_info = [];
+
 // *CWL* Global names for DOM ids used
 var domElement = "domElement";
 var domGroup = "domGroup";
@@ -49,6 +52,8 @@ var fetch = function(container, urls, index) {
             var inner;
             inner = $('<div id="' + domElement + index + '" ></div>');
 
+	    var jsGridRow = {};
+
             // **CWL** Kind of a hack for now. Establish a string->meta lookuptable.
             elementLookup[nativeObject.repo] = index;
 
@@ -60,15 +65,22 @@ var fetch = function(container, urls, index) {
             container.append(inner);
 
             inner.append('<p><b>Repo:</b> ' + nativeObject.repo + '</p>');
+	    jsGridRow["Repo"] = nativeObject.repo;
+
             inner.append('<p><b>Short Description:</b> ' + nativeObject.shortDescription + '</p>');
+	    jsGridRow["Description"] = nativeObject.shortDescription;
+
             if (nativeObject.documentation != undefined) {
                 inner.append('<p><b>Documentation:</b> <a href=\"' + nativeObject.documentation + '\" target=\"blank\">' + nativeObject.documentation + '</a></p>');
+		jsGridRow["Documentation"] = nativeObject.documentation;
             } else {
                 inner.append('<p><b>Documentation:</b> None</p>');
+		jsGridRow["Documentation"] = "None";
             }
 
             inner.append('<p><b>Coordinator:</b> ' +
                 nativeObject.coordinator + '</p>');
+	    jsGridRow["Coordinator"] = nativeObject.coordinator;
 
             if (nativeObject.parent != undefined) {
                 inner.append('<p><b>Parent:</b> <a class="btn btn-link" href="' + repo_url + nativeObject.parent[0] + '">Visit Repo</a> <a class="btn btn-primary btn-xs navBtn" href="#">' + nativeObject.parent[0] + '</a></p>');
@@ -103,6 +115,7 @@ var fetch = function(container, urls, index) {
             }
 
             inner.append('<hr style="height: 1px; border-color: black;">');
+	    metadata_info[index] = jsGridRow;
 
             // fetch next
             if (urls.length - 1 > index) {
@@ -114,6 +127,8 @@ var fetch = function(container, urls, index) {
                 // handle asynchrony issues by making sure all elements
                 // are populated.
                 cwlpager_init(container);
+
+		constructJsGrid();
                 
                 // hide spinner
                 $('#spinner-container').hide();
@@ -125,11 +140,46 @@ var fetch = function(container, urls, index) {
             alert('GET failed.');
         }
     });
-}
+};
+
+var activateGrid = function() {
+    $("#grid-view-master").show();
+    $("#tab-view-master").hide();
+};
+
+var activateTab = function() {
+    $("#grid-view-master").hide();
+    $("#tab-view-master").show();
+};
+
+var constructJsGrid = function() {
+    $("#jsGrid").jsGrid({
+	    width: "100%",
+		height: "auto",
+		
+		inserting: false,
+		editing: false,
+		sorting: true,
+		paging: true,
+		pageSize: 10,
+		
+		data: metadata_info,
+		
+		fields: [
+			 { name: "Repo", type: "text", width: "auto", validate: "required" },
+			 { name: "Documentation", type: "text", width: "auto" },
+			 { name: "Description", type: "text", width: "auto" },
+			 { name: "Coordinator", type: "text", width: "auto" }
+			 //			 { type: "control" }
+			 ]
+		});
+};
 
 $(function() {
-    var container = $('#content');
-    $('#content').hide();
-    
-    fetch(container, urls, 0);
-});
+	var container = $('#content');
+	$('#content').hide();
+	
+	$("#tab-view-master").hide();
+	
+	fetch(container, urls, 0);
+    });

--- a/war/repositories.html
+++ b/war/repositories.html
@@ -19,12 +19,9 @@
 		<link href="css/main.css" rel="stylesheet">
 		<link href="css/docs.css" rel="stylesheet">
 
-
-		<script type="text/javascript" src="js/jquery-1.8.3.min.js"></script>
-		<script type="text/javascript" src="js/yaml.js"></script>
-		<script type="text/javascript" src="js/repositories.js"></script>
-		<script type="text/javascript" src="js/cwl-hierarchy.js"></script>
-		<script type="text/javascript" src="js/cwlpager.js"></script>
+		<!-- CDN jsGrid styles -->
+		<link type="text/css" rel="stylesheet" href="http://js-grid.com/css/jsgrid.min.css" />
+		<link type="text/css" rel="stylesheet" href="http://js-grid.com/css/jsgrid-theme.min.css" />
 
 		<!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
 		<!--[if lt IE 9]>
@@ -95,18 +92,49 @@
 			</div>
 		</header>
 
+		<!-- Automatic Bootstrap Tabbing 
+		     (Doesn't work - clicking on tab pills doesn't change the tab pane)  
 		<div class="container">
-			<div class="row-fluid">
-				<div class="span12">
-					<ul id="tabber" class="nav nav-tabs">
-					</ul>
-					<div id="content" class="tab-content" style="margin-top: 25px;">
-					</div>
-					<div id='spinner-container' style="text-align: center; margin: 100px 0px 100px 0px;">
-						<i id='spinner' class="fa fa-gear fa-spin" style="font-size: 60px"></i>
-					</div>
-				</div>
+		  <ul class="nav nav-pills" id="view-choice">
+		    <li class="active"><a data-toggle="pill" href="#view1">View 1</a></li>
+		    <li><a data-toggle="pill" href="#view2">View 2</a></li>
+		  </ul>
+		  <div class="tab-content">
+		    <div class="tab-pane fade in active" id="view1">
+		      <p>Grid Test 1</p>
+		    </div>
+		    <div class="tab-pane fade" id="view2">
+		      <p>Grid Test 2</p>
+		    </div>
+		  </div>
+		</div>
+		  -->
+
+		<!-- Manual Tabbing -->
+		<div class="container">
+		  <ul class="nav nav-pills" id="view-choice">
+		    <li class="active"><a onclick="activateGrid()" href="#">Grid View</a></li>
+		    <li><a onclick="activateTab()" href="#">Tabbed View</a></li>
+		  </ul>
+
+		  <div id="grid-view-master">
+		    <div id="jsGrid"></div>
+		  </div>
+
+		  <div id="tab-view-master">
+		    <div class="row-fluid">
+		      <div class="span12">
+			<ul id="tabber" class="nav nav-tabs">
+			</ul>
+			<div id="content" class="tab-content" style="margin-top: 25px;">
 			</div>
+			<div id='spinner-container' style="text-align: center; margin: 100px 0px 100px 0px;">
+			  <i id='spinner' class="fa fa-gear fa-spin" style="font-size: 60px"></i>
+			</div>
+		      </div>
+		    </div>
+		  </div>
+
 		</div>
 	
 		<!-- Footer ================================================== -->
@@ -194,6 +222,14 @@
 		<!-- Placed at the end of the document so the pages load faster -->
 		<script type="text/javascript" src="http://platform.twitter.com/widgets.js"></script>
 		<script src="js/jquery-1.8.3.min.js"></script>
+		<script type="text/javascript" src="js/yaml.js"></script>
+		<script type="text/javascript" src="js/repositories.js"></script>
+		<script type="text/javascript" src="js/cwl-hierarchy.js"></script>
+		<script type="text/javascript" src="js/cwlpager.js"></script>
+
+		<!-- CDN jsGrid scripts --> 
+		<script type="text/javascript" src="http://js-grid.com/js/jsgrid.min.js"></script>
+
 		<script type="text/javascript" src="js/jquery.parss.uncompressed.js"></script>
 		<script src="js/main.js"></script>
 		<script src="js/bootstrap.js"></script>


### PR DESCRIPTION
Tabbed pane switches between the original tab-hierarchical view, and the new (currently flat) grid-based view implemented using jsGrid. New grid-based view is also partial, presenting only basic data fields until a decision is made on how best to organize it for this particular view.