### PR TITLE
Fix Delaware corporate number

### DIFF
--- a/war/about.html
+++ b/war/about.html
@@ -174,7 +174,7 @@
 						<h1>Who?</h1>
 						<p class="marketing-byline">
 							We are a highly motivated <a href="./people.html">group of individuals</a> who believe in Open Science.<br/>
-							In July 2015 we incorporated the OpenWorm Foundation as a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5785727</a> as a way to help us achieve the long term goals of the project. 
+							In July 2015 we incorporated the OpenWorm Foundation as a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5787527</a> as a way to help us achieve the long term goals of the project. 
 						</p>
 						 
 					</div>
@@ -260,7 +260,7 @@
 							    © 2011-2016 OpenWorm - All rights reserved.
 							</p>
 							<p>
-							    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5785727</a>, incorporated in July 2015.
+							    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5787527</a>, incorporated in July 2015.
 							</p>
 		                    <p>
 		                        Code licensed under <a href="http://opensource.org/licenses/MIT" target="_blank">MIT</a>, documentation under <a href="http://creativecommons.org/licenses/by/3.0/" target="_blank">CC BY 3.0</a>.

--- a/war/contacts.html
+++ b/war/contacts.html
@@ -196,7 +196,7 @@
     © 2011-2016 OpenWorm - All rights reserved.
 </p>
 <p>
-    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5785727</a>, incorporated in July 2015.
+    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5787527</a>, incorporated in July 2015.
 </p>
 		                    <p>
 		                        Code licensed under <a href="http://opensource.org/licenses/MIT" target="_blank">MIT</a>, documentation under <a href="http://creativecommons.org/licenses/by/3.0/" target="_blank">CC BY 3.0</a>.

--- a/war/donate.html
+++ b/war/donate.html
@@ -271,7 +271,7 @@
     © 2011-2016 OpenWorm - All rights reserved.
 </p>
 <p>
-    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5785727</a>, incorporated in July 2015.
+    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5787527</a>, incorporated in July 2015.
 </p>
 		                    <p>
 		                        Code licensed under <a href="http://opensource.org/licenses/MIT" target="_blank">MIT</a>, documentation under <a href="http://creativecommons.org/licenses/by/3.0/" target="_blank">CC BY 3.0</a>.

--- a/war/downloads.html
+++ b/war/downloads.html
@@ -238,7 +238,7 @@
     © 2011-2016 OpenWorm - All rights reserved.
 </p>
 <p>
-    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5785727</a>, incorporated in July 2015.
+    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5787527</a>, incorporated in July 2015.
 </p>
 		                    <p>
 		                        Code licensed under <a href="http://opensource.org/licenses/MIT" target="_blank">MIT</a>, documentation under <a href="http://creativecommons.org/licenses/by/3.0/" target="_blank">CC BY 3.0</a>.

--- a/war/educators.html
+++ b/war/educators.html
@@ -261,7 +261,7 @@
     © 2011-2016 OpenWorm - All rights reserved.
 </p>
 <p>
-    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5785727</a>, incorporated in July 2015.
+    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5787527</a>, incorporated in July 2015.
 </p>
 		                    <p>
 		                        Code licensed under <a href="http://opensource.org/licenses/MIT" target="_blank">MIT</a>, documentation under <a href="http://creativecommons.org/licenses/by/3.0/" target="_blank">CC BY 3.0</a>.

--- a/war/events.html
+++ b/war/events.html
@@ -286,7 +286,7 @@
     © 2011-2016 OpenWorm - All rights reserved.
 </p>
 <p>
-    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5785727</a>, incorporated in July 2015.
+    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5787527</a>, incorporated in July 2015.
 </p>
 		                    <p>
 		                        Code licensed under <a href="http://opensource.org/licenses/MIT" target="_blank">MIT</a>, documentation under <a href="http://creativecommons.org/licenses/by/3.0/" target="_blank">CC BY 3.0</a>.

--- a/war/get_involved.html
+++ b/war/get_involved.html
@@ -326,7 +326,7 @@
     © 2011-2016 OpenWorm - All rights reserved.
 </p>
 <p>
-    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5785727</a>, incorporated in July 2015.
+    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5787527</a>, incorporated in July 2015.
 </p>
 		                    <p>
 		                        Code licensed under <a href="http://opensource.org/licenses/MIT" target="_blank">MIT</a>, documentation under <a href="http://creativecommons.org/licenses/by/3.0/" target="_blank">CC BY 3.0</a>.

--- a/war/getting_started.html
+++ b/war/getting_started.html
@@ -358,7 +358,7 @@
     © 2011-2016 OpenWorm - All rights reserved.
 </p>
 <p>
-    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5785727</a>, incorporated in July 2015.
+    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5787527</a>, incorporated in July 2015.
 </p>
 		                    <p>
 		                        Code licensed under <a href="http://opensource.org/licenses/MIT" target="_blank">MIT</a>, documentation under <a href="http://creativecommons.org/licenses/by/3.0/" target="_blank">CC BY 3.0</a>.

--- a/war/index.html
+++ b/war/index.html
@@ -477,7 +477,7 @@
 			                        © 2011-2016 OpenWorm Foundation - All rights reserved. 
 			                    </p>
 			                    <p>
-			                        OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5785727</a>, incorporated in July 2015.
+			                        OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5787527</a>, incorporated in July 2015.
 			                    </p>
 			                    <p>
 			                        Code licensed under <a href="http://opensource.org/licenses/MIT" target="_blank">MIT</a>, documentation under <a target="_blank" href="http://creativecommons.org/licenses/by/3.0/" target="_blank">CC BY 3.0</a>.

--- a/war/media.html
+++ b/war/media.html
@@ -264,7 +264,7 @@
     © 2011-2016 OpenWorm - All rights reserved.
 </p>
 <p>
-    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5785727</a>, incorporated in July 2015.
+    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5787527</a>, incorporated in July 2015.
 </p>
 		                    <p>
 		                        Code licensed under <a href="http://opensource.org/licenses/MIT" target="_blank">MIT</a>, documentation under <a href="http://creativecommons.org/licenses/by/3.0/" target="_blank">CC BY 3.0</a>.

--- a/war/publications.html
+++ b/war/publications.html
@@ -321,7 +321,7 @@ experiments, as well as performance benchmarks, are presented and future directi
     © 2011-2016 OpenWorm - All rights reserved.
 </p>
 <p>
-    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5785727</a>, incorporated in July 2015.
+    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5787527</a>, incorporated in July 2015.
 </p>
 		                    <p>
 		                        Code licensed under <a href="http://opensource.org/licenses/MIT" target="_blank">MIT</a>, documentation under <a href="http://creativecommons.org/licenses/by/3.0/" target="_blank">CC BY 3.0</a>.

--- a/war/science.html
+++ b/war/science.html
@@ -546,7 +546,7 @@
     © 2011-2016 OpenWorm - All rights reserved.
 </p>
 <p>
-    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5785727</a>, incorporated in July 2015.
+    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5787527</a>, incorporated in July 2015.
 </p>
 		                    <p>
 		                        Code licensed under <a href="http://opensource.org/licenses/MIT" target="_blank">MIT</a>, documentation under <a href="http://creativecommons.org/licenses/by/3.0/" target="_blank">CC BY 3.0</a>.

--- a/war/supporters.html
+++ b/war/supporters.html
@@ -1391,7 +1391,7 @@
 							    © 2011-2016 OpenWorm - All rights reserved.
 							</p>
 							<p>
-							    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5785727</a>, incorporated in July 2015.
+							    OpenWorm Foundation is a Delaware not-for-profit Corporation <a target="_blank" href="/assets/OpenWormFoundationIncorporationCertificate.pdf">#5787527</a>, incorporated in July 2015.
 							</p>
 		                    <p>
 		                        Code licensed under <a href="http://opensource.org/licenses/MIT" target="_blank">MIT</a>, documentation under <a href="http://creativecommons.org/licenses/by/3.0/" target="_blank">CC BY 3.0</a>.


### PR DESCRIPTION
There was a typo in the Delaware nonprofit corporation number we had for OpenWorm Foundation.

#5787527 (YES)
#5785727 (NO, typo, fixed 17 Feb 2017)