### PR TITLE
update for python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,14 @@ org.openworm.website
 
 Runs as a google app engine application, but can serve up simple content via a Python simple server:
 
+For Python 2.x use: 
+
     cd war
     python -m SimpleHTTPServer
+
+For Python 3.x use:
+
+    cd war
+    python -m http.server
 
 Point your browser at: http://127.0.0.1:8000/


### PR DESCRIPTION
SimpleHTTPServer has been replaced by http.server in Python 3